### PR TITLE
Update dune-project to fix opam-repo comments

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,6 @@
  (description "Serde is a serialization framework for OCaml that runs on the principle of maximum efficiency and user ergonomics while maintaining format flexibility. Internally Serde uses an intermediate language that can be cheaply mapped to and from different target formats like JSON, XML, or S-expressions, which makes Serde good for transcoding data as well.")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
    (ocamlformat (>= "0.17.0"))
    (ppx_inline_test (>= "0.16.0"))
    ))
@@ -30,10 +29,9 @@
  (description "These macros help derive serializers and deserializers for your existing types and provide all the functionality you expect to plug in different data-formats.")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
    (ppxlib (>= "0.28.0"))
    (ppx_deriving (>= "5.2.1"))
-   (serde (= "0.0.1"))
+   (serde (= :version))
    ))
 
 (package
@@ -41,9 +39,8 @@
  (synopsis "S-expression format support for Serde")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
-   (serde (= "0.0.1"))
-   (serde_derive (= "0.0.1"))
+   (serde (= :version))
+   (serde_derive (= :version))
    (sexplib (>= "0.16.0"))
    ))
 
@@ -52,9 +49,8 @@
  (synopsis "JSON format support for Serde")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
-   (serde (= "0.0.1"))
-   (serde_derive (= "0.0.1"))
+   (serde (= :version))
+   (serde_derive (= :version))
    (yojson (>= "2.1.0"))
    ))
 
@@ -63,9 +59,8 @@
  (synopsis "XML format support for Serde")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
-   (serde (= "0.0.1"))
-   (serde_derive (= "0.0.1"))
+   (serde (= :version))
+   (serde_derive (= :version))
    (tyxml (>= "4.5.0"))
    ))
 
@@ -74,7 +69,6 @@
  (synopsis "A human-friendly format for Serde that helps you debug any data during development")
  (depends
    (ocaml (>= "4.12.0"))
-   (dune (>= "3.5"))
-   (serde (= "0.0.1"))
-   (serde_derive (= "0.0.1"))
+   (serde (= :version))
+   (serde_derive (= :version))
    ))

--- a/serde.opam
+++ b/serde.opam
@@ -9,8 +9,8 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
   "ocamlformat" {>= "0.17.0"}
   "ppx_inline_test" {>= "0.16.0"}
   "odoc" {with-doc}

--- a/serde_debug.opam
+++ b/serde_debug.opam
@@ -8,10 +8,10 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
-  "serde" {= "0.0.1"}
-  "serde_derive" {= "0.0.1"}
+  "serde" {= version}
+  "serde_derive" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/serde_derive.opam
+++ b/serde_derive.opam
@@ -9,11 +9,11 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
   "ppxlib" {>= "0.28.0"}
   "ppx_deriving" {>= "5.2.1"}
-  "serde" {= "0.0.1"}
+  "serde" {= version}
   "odoc" {with-doc}
 ]
 build: [

--- a/serde_json.opam
+++ b/serde_json.opam
@@ -7,10 +7,10 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
-  "serde" {= "0.0.1"}
-  "serde_derive" {= "0.0.1"}
+  "serde" {= version}
+  "serde_derive" {= version}
   "yojson" {>= "2.1.0"}
   "odoc" {with-doc}
 ]

--- a/serde_sexpr.opam
+++ b/serde_sexpr.opam
@@ -7,10 +7,10 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
-  "serde" {= "0.0.1"}
-  "serde_derive" {= "0.0.1"}
+  "serde" {= version}
+  "serde_derive" {= version}
   "sexplib" {>= "0.16.0"}
   "odoc" {with-doc}
 ]

--- a/serde_xml.opam
+++ b/serde_xml.opam
@@ -7,10 +7,10 @@ license: "MIT"
 homepage: "https://github.com/leostera/serde.ml"
 bug-reports: "https://github.com/leostera/serde.ml/issues"
 depends: [
+  "dune" {>= "3.5"}
   "ocaml" {>= "4.12.0"}
-  "dune" {>= "3.5" & >= "3.5"}
-  "serde" {= "0.0.1"}
-  "serde_derive" {= "0.0.1"}
+  "serde" {= version}
+  "serde_derive" {= version}
   "tyxml" {>= "4.5.0"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
Dune automatically adds itself with the correct version, removing it from the dune-project dependencies will fix the duplicate lower bound.

Using `:version` for the cross package bounds will ensure that your package does not need further bounds changes for future releases.