### PR TITLE
Read end of object JSON tokens correctly

### DIFF
--- a/serde_json/json.ml
+++ b/serde_json/json.ml
@@ -52,7 +52,8 @@ module Parser = struct
     _run (fun () -> Yojson.Safe.read_object_sep yojson lexbuf)
 
   let read_object_end { lexbuf; _ } =
-    _run (fun () -> Yojson.Safe.read_object_end lexbuf)
+    _run (fun () ->
+        try Yojson.Safe.read_object_end lexbuf with Yojson.End_of_object -> ())
 
   let read_open_bracket { yojson; lexbuf } =
     _run (fun () -> Yojson.Safe.read_lbr yojson lexbuf)

--- a/serde_json/json_de.ml
+++ b/serde_json/json_de.ml
@@ -144,8 +144,8 @@ Serde.De.Make (struct
           | _ -> Ok ()
         in
         Json.Parser.skip_space state;
-        match Json.Parser.peek state with
-        | Some '}' -> Ok value
+        match Json.Parser.read_object_end state with
+        | Ok () -> Ok value
         | _ -> Error.message "expected closed bracket to close a sequence")
     | Some c ->
         Error.message

--- a/serde_json/test.ml
+++ b/serde_json/test.ml
@@ -95,11 +95,14 @@ module Type_record = struct
 end
 
 module Type_variant = struct
+  type name = { first : string; last : string }
+  [@@deriving eq, serializer, deserializer]
+
   type variant =
     | Hello
     | Tuple1 of string
     | Tuple2 of string * Type_alias.alias
-    | Record3 of { name : string; favorite_number : int; location : string }
+    | Record3 of { name : name; favorite_number : int; location : string }
   [@@deriving eq, serializer, deserializer]
 
   let parse_json = parse_json equal_variant deserialize_variant
@@ -113,21 +116,32 @@ module Type_variant = struct
       (Tuple2 ("this is a tuple", 1))
 
   let%test _ =
-    parse_json {|{ "Record3": ["Benjamin Sisko", 9, "Bajor"] }|}
+    parse_json {|{ "Record3": [ ["Benjamin", "Sisko"], 9, "Bajor"] }|}
       (Record3
-         { name = "Benjamin Sisko"; favorite_number = 9; location = "Bajor" })
+         {
+           name = { first = "Benjamin"; last = "Sisko" };
+           favorite_number = 9;
+           location = "Bajor";
+         })
 
   let%test _ =
     parse_json
       {|{
     "Record3": {
-      "name": "Benjamin Sisko",
+      "name": {
+        "first": "Benjamin",
+        "last": "Sisko",
+      },
       "favorite_number": 9,
       "location": "Bajor"
     }
   }|}
       (Record3
-         { name = "Benjamin Sisko"; favorite_number = 9; location = "Bajor" })
+         {
+           name = { first = "Benjamin"; last = "Sisko" };
+           favorite_number = 9;
+           location = "Bajor";
+         })
 end
 
 (*


### PR DESCRIPTION
This fixes a bug where `serde` would be unable to deserialize JSON objects with nested records.

This happened because any encounter of `}` would not be read by the parser (it only peeked at the value), which causes it to speedrun to the end of the object.

I adjusted the final test to have a nested record instead, but basically, before this PR:

```json
{
  "Record3": {
    "name": {
      "first": "Petri",
      "last": "Last"
    },
    "age": 28
  }
}
```

Would never parse `"age": 28` , resulting in `Missing_field` errors.

Now `Json.Parser.read_object_end` is called to read the `}`, and the `Yojson.End_of_object` error raised when the end of an object is encountered is handled by ignoring it (as it is expected state).