### PR TITLE
Deserialize optional values as Option

### DIFF
--- a/serde_derive/de_base.ml
+++ b/serde_derive/de_base.ml
@@ -10,8 +10,12 @@ let var ~ctxt name =
 
 let longident ~ctxt name = name |> Longident.parse |> var ~ctxt
 
-let is_primitive_type (t : core_type) =
+let rec is_primitive_type (t : core_type) =
   match t.ptyp_desc with
+  | Ptyp_constr (name, [ tp ]) -> (
+      match name.txt |> Longident.name with
+      | "option" -> is_primitive_type tp
+      | _ -> false)
   | Ptyp_constr (name, _) -> (
       match name.txt |> Longident.name with
       | "bool" | "char" | "float" | "int" | "string" | "unit" -> true
@@ -20,10 +24,16 @@ let is_primitive_type (t : core_type) =
 
 (** visitor / deserializer resolution *)
 
-let de_fun ~ctxt (t : core_type) =
+let rec de_fun ~ctxt (t : core_type) =
   let loc = loc ~ctxt in
   match t.ptyp_desc with
   (* Serialize a constructor *)
+  | Ptyp_constr (name, [ tp ]) -> (
+      match name.txt |> Longident.name with
+      | "option" ->
+          let e = de_fun ~ctxt tp in
+          [%expr [%e e]]
+      | _ -> [%expr ()])
   | Ptyp_constr (name, _) -> (
       match name.txt |> Longident.name with
       | "bool" -> [%expr Serde.De.deserialize_bool]
@@ -76,10 +86,14 @@ let de_fun ~ctxt (t : core_type) =
       Printf.printf "found arrow";
       [%expr ()]
 
-let visitor_mod ~ctxt (t : core_type) =
+let rec visitor_mod ~ctxt (t : core_type) =
   let loc = loc ~ctxt in
   match t.ptyp_desc with
   (* Serialize a constructor *)
+  | Ptyp_constr (name, [ tp ]) -> (
+      match name.txt |> Longident.name with
+      | "option" -> visitor_mod ~ctxt tp
+      | _ -> None)
   | Ptyp_constr (name, _) -> (
       match name.txt |> Longident.name with
       | "bool" -> Some [%expr (module Serde.De.Impls.Bool_visitor)]


### PR DESCRIPTION
Adds support for optional value deserialization.

When deserializing an object, if a field is missing _and_ that field is defined as an `option`, it is deserialized to `None` . Otherwise it is deserialized to `Some val`

This works for the primitive types as well as more complex types, as shown in the added unit tests.

Given the following type:

```ocaml
type name = {
  first : string;
  last : string option;
}
[@@deriving deserializer]
```

deserializing the following json:

```json
{ "first": "Petri" }
```

will result in an object

```ocaml
{ first = "Petri", last = None}
```