### PR TITLE
Deserialize nulls and missing values as Options

### DIFF
--- a/serde/de/de.ml
+++ b/serde/de/de.ml
@@ -91,11 +91,11 @@ let deserialize_record_option :
     ('a, 'error de_error) result) ->
     (module Deserializer with type state = state) ->
     ('a option, 'error de_error) result =
- fun fn (module Self) ->
-  match Self.deserialize_null Self.state (module Self) with
+ fun fn (module De) ->
+  match De.deserialize_null De.state (module De) with
   | Ok _ -> Ok None
   | _ -> (
-      match fn (module Self) with Ok x -> Ok (Some x) | Error _ as err -> err)
+      match fn (module De) with Ok x -> Ok (Some x) | Error _ as err -> err)
 
 let deserialize_identifier :
     type value state.

--- a/serde/de/de.ml
+++ b/serde/de/de.ml
@@ -105,28 +105,6 @@ let deserialize_identifier :
   | exception e -> Error.unexpected_exception e
   | res -> res
 
-let deserialize_option_record :
-    type value field state.
-    (state Deserializer.t ->
-    (value, field) Visitor.with_tag ->
-    field Visitor.t ->
-    name:string ->
-    fields:string list ->
-    (value, 'error de_error) result) ->
-    state Deserializer.t ->
-    (value, field) Visitor.with_tag ->
-    field Visitor.t ->
-    name:string ->
-    fields:string list ->
-    (value option, 'error de_error) result =
- fun fn (module De) (module V) (module Field) ~name ~fields ->
-  match De.deserialize_null De.state (module De) with
-  | Ok _ -> Ok None
-  | _ -> (
-      match fn (module De) (module V) (module Field) ~name ~fields with
-      | Ok x -> Ok (Some x)
-      | Error _ as err -> err)
-
 let deserialize_record :
     type value field state.
     state Deserializer.t ->

--- a/serde/de/de.ml
+++ b/serde/de/de.ml
@@ -93,9 +93,10 @@ let deserialize_record_option :
     ('a option, 'error de_error) result =
  fun fn (module De) ->
   match De.deserialize_null De.state (module De) with
-  | Ok _ -> Ok None
-  | _ -> (
-      match fn (module De) with Ok x -> Ok (Some x) | Error _ as err -> err)
+  | Ok () -> Ok None
+  | Error _err ->
+      let* result = fn (module De) in
+      Ok (Some result)
 
 let deserialize_identifier :
     type value state.

--- a/serde/de/intf.ml
+++ b/serde/de/intf.ml
@@ -73,6 +73,12 @@ module rec Rec : sig
       (module Rec.Visitor_intf with type value = 'value) ->
       ('value, 'error Error.de_error) result
 
+    val deserialize_null :
+      'value 'error.
+      state ->
+      (module Rec.Deserializer_intf with type state = state) ->
+      ('value option, 'error Error.de_error) result
+
     val deserialize_unit :
       'value 'error.
       state ->
@@ -244,6 +250,12 @@ end = struct
       (module Rec.Deserializer_intf with type state = state) ->
       (module Rec.Visitor_intf with type value = 'value) ->
       ('value, 'error Error.de_error) result
+
+    val deserialize_null :
+      'value 'error.
+      state ->
+      (module Rec.Deserializer_intf with type state = state) ->
+      ('value option, 'error Error.de_error) result
 
     val deserialize_unit :
       'value 'error.

--- a/serde_derive/de_record.ml
+++ b/serde_derive/de_record.ml
@@ -2,6 +2,11 @@ open Ppxlib
 module Ast = Ast_builder.Default
 open De_base
 
+let ctyp_is_option ctyp =
+  match ctyp.ptyp_desc with
+  | Ptyp_constr (name, _) -> name.txt |> Longident.name = "option"
+  | _ -> false
+
 (** implementation *)
 let gen_visit_map ~ctxt ~type_name:_ ?constructor ~field_visitor kvs parts =
   let loc = loc ~ctxt in
@@ -21,13 +26,18 @@ let gen_visit_map ~ctxt ~type_name:_ ?constructor ~field_visitor kvs parts =
 
   let extract_fields =
     List.fold_left
-      (fun body (name, pat, _ctyp, exp, _field_variant) ->
+      (fun body (name, pat, ctyp, exp, _field_variant) ->
         let op = var ~ctxt "let*" in
         let exp =
-          [%expr
-            match ![%e exp] with
-            | Some value -> Ok value
-            | None -> Serde.De.Error.missing_field [%e name |> Ast.estring ~loc]]
+          if ctyp_is_option ctyp then
+            [%expr
+              match ![%e exp] with Some value -> Ok value | None -> Ok None]
+          else
+            [%expr
+              match ![%e exp] with
+              | Some value -> Ok value
+              | None ->
+                  Serde.De.Error.missing_field [%e name |> Ast.estring ~loc]]
         in
         let let_ = Ast.binding_op ~op ~loc ~pat ~exp in
         Ast.letop ~let_ ~ands:[] ~body |> Ast.pexp_letop ~loc)

--- a/serde_json/json.ml
+++ b/serde_json/json.ml
@@ -45,6 +45,9 @@ module Parser = struct
   let read_int { yojson; lexbuf } =
     _run (fun () -> Yojson.Safe.read_int yojson lexbuf)
 
+  let read_null_if_possible { yojson; lexbuf } =
+    _run (fun () -> Yojson.Safe.read_null_if_possible yojson lexbuf)
+
   let read_object_start { yojson; lexbuf } =
     _run (fun () -> Yojson.Safe.read_lcurl yojson lexbuf)
 

--- a/serde_json/json_de.ml
+++ b/serde_json/json_de.ml
@@ -56,13 +56,8 @@ Serde.De.Make (struct
       state -> state Deserializer.t -> (value option, 'error de_error) result =
    fun state (module Self) ->
     Json.Parser.skip_space state;
-    if
-      not
-        (match Json.Parser.read_null_if_possible state with
-        | Ok b -> b
-        | Error _ -> false)
-    then Error.message "not null"
-    else Ok None
+    let* is_null = Json.Parser.read_null_if_possible state in
+    if is_null then Ok () else Error.message "not null"
 
   let deserialize_seq :
       type value.

--- a/serde_json/json_de.ml
+++ b/serde_json/json_de.ml
@@ -51,6 +51,19 @@ Serde.De.Make (struct
     let* string = Json.Parser.read_string state in
     V.visit_string string
 
+  let deserialize_null :
+      type value.
+      state -> state Deserializer.t -> (value option, 'error de_error) result =
+   fun state (module Self) ->
+    Json.Parser.skip_space state;
+    if
+      not
+        (match Json.Parser.read_null_if_possible state with
+        | Ok b -> b
+        | Error _ -> false)
+    then Error.message "not null"
+    else Ok None
+
   let deserialize_seq :
       type value.
       state ->

--- a/serde_json/test.ml
+++ b/serde_json/test.ml
@@ -94,6 +94,114 @@ module Type_record = struct
       { r_name = "Benjamin Sisko"; r_favorite_number = 9; r_location = "Bajor" }
 end
 
+module Type_record_optional = struct
+  type record = {
+    r_name : string;
+    r_favorite_number : int;
+    r_location : string option;
+  }
+  [@@deriving eq, deserializer]
+
+  let parse_json = parse_json equal_record deserialize_record
+
+  let%test "parse packed json representation" =
+    parse_json {| [ "Benjamin Sisko", 9, "Bajor", ] |}
+      {
+        r_name = "Benjamin Sisko";
+        r_favorite_number = 9;
+        r_location = Some "Bajor";
+      }
+
+  let%test "parse object json representation" =
+    parse_json
+      {|
+  { "r_name": "Benjamin Sisko",
+    "r_favorite_number": 9,
+    "r_location": "Bajor"
+  }
+  |}
+      {
+        r_name = "Benjamin Sisko";
+        r_favorite_number = 9;
+        r_location = Some "Bajor";
+      }
+
+  let%test "parse object json representation missing value" =
+    parse_json
+      {|
+  { "r_name": "Benjamin Sisko",
+    "r_favorite_number": 9
+  }
+  |}
+      { r_name = "Benjamin Sisko"; r_favorite_number = 9; r_location = None }
+
+  let%test "parse object json representation explicit null" =
+    parse_json
+      {|
+  { "r_name": "Benjamin Sisko",
+    "r_favorite_number": 9,
+    "r_location": null
+  }
+  |}
+      { r_name = "Benjamin Sisko"; r_favorite_number = 9; r_location = None }
+end
+
+module Type_record_complex_optional = struct
+  type name = { r_first : string; r_last : string }
+  [@@deriving eq, deserializer]
+
+  type record = {
+    r_name : name option;
+    r_favorite_number : int;
+    r_location : string option;
+  }
+  [@@deriving eq, deserializer]
+
+  let parse_json = parse_json equal_record deserialize_record
+
+  let%test "parse packed json representation" =
+    parse_json {| [ [ "Benjamin", "Sisko" ], 9, "Bajor", ] |}
+      {
+        r_name = Some { r_first = "Benjamin"; r_last = "Sisko" };
+        r_favorite_number = 9;
+        r_location = Some "Bajor";
+      }
+
+  let%test "parse object json representation" =
+    parse_json
+      {|
+  { "r_name": {
+      "r_first": "Benjamin",
+      "r_last": "Sisko"
+    },
+    "r_favorite_number": 9,
+    "r_location": "Bajor"
+  }
+  |}
+      {
+        r_name = Some { r_first = "Benjamin"; r_last = "Sisko" };
+        r_favorite_number = 9;
+        r_location = Some "Bajor";
+      }
+
+  let%test "parse object json representation missing values" =
+    parse_json {|
+  { "r_favorite_number": 9
+  }
+  |}
+      { r_name = None; r_favorite_number = 9; r_location = None }
+
+  let%test "parse object json representation explicit nulls" =
+    parse_json
+      {|
+  { "r_name": null,
+    "r_favorite_number": 9,
+    "r_location": null
+  }
+  |}
+      { r_name = None; r_favorite_number = 9; r_location = None }
+end
+
 module Type_variant = struct
   type name = { first : string; last : string }
   [@@deriving eq, serializer, deserializer]

--- a/serde_sexpr/sexpr_de.ml
+++ b/serde_sexpr/sexpr_de.ml
@@ -111,6 +111,11 @@ Serde.De.Make (struct
             found: " ^ String.make 1 c)
     | None -> Error.message "end of stream!"
 
+  let deserialize_null :
+      type value.
+      state -> state Deserializer.t -> (value option, 'error de_error) result =
+   fun _ (module De) -> Error.unimplemented "uNimplemented: deserialize_null"
+
   let deserialize_seq :
       type value.
       state ->

--- a/serde_sexpr/sexpr_de.ml
+++ b/serde_sexpr/sexpr_de.ml
@@ -114,7 +114,7 @@ Serde.De.Make (struct
   let deserialize_null :
       type value.
       state -> state Deserializer.t -> (value option, 'error de_error) result =
-   fun _ (module De) -> Error.unimplemented "uNimplemented: deserialize_null"
+   fun _ (module De) -> Error.unimplemented "unimplemented: deserialize_null"
 
   let deserialize_seq :
       type value.


### PR DESCRIPTION
Adds support for optional value deserialization.

When deserializing an object, if a field is missing _and_ that field is defined as an `option`, it is deserialized to `None` . Otherwise it is deserialized to `Some val`

This works for the primitive types as well as more complex types, as shown in the added unit tests.

Given the following type:

```ocaml
type name = {
  first : string;
  last : string option;
}
[@@deriving deserializer]
```

deserializing the following json:

```json
{ "first": "Petri" }
```

or

```json
{ "first": "Petri" , "last": null }
```

will result in an object

```ocaml
{ first = "Petri", last = None}
```

and

```json
{ "first": "Petri", "last": "Last" }
```

will result in

```ocaml
{ first = "Petri", last = Some "Last" }
```